### PR TITLE
use scratch as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . $APPPATH
 RUN cd $APPPATH && go get -d && go build -o /bin/couchdb-prometheus-exporter
 
 
-FROM alpine:edge
+FROM scratch
 LABEL maintainer="Tobias Gesellchen <tobias@gesellix.de> (@gesellix)"
 
 EXPOSE 9984

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM alpine:edge AS builder
 LABEL builder=true
 
+ENV CGO_ENABLED=0
 ENV GOPATH /go
 ENV APPPATH $GOPATH/src/github.com/gesellix/couchdb-prometheus-exporter
 
 RUN adduser -DH user
 RUN apk add --update -t build-deps go git mercurial libc-dev gcc libgcc
 COPY . $APPPATH
-RUN cd $APPPATH && go get -d && go build -o /bin/couchdb-prometheus-exporter
-
+RUN cd $APPPATH && go get -d \
+ && go build \
+    -a \
+    -ldflags '-extldflags "-static"' \
+    -o /bin/couchdb-prometheus-exporter
 
 FROM scratch
 LABEL maintainer="Tobias Gesellchen <tobias@gesellix.de> (@gesellix)"


### PR DESCRIPTION
... running it like this won't work:

````
$ docker network create couchdb
$ docker run --rm -it -p 9984:9984 --network couchdb gesellix/couchdb-prometheus-exporter -logtostderr -couchdb.uri=http://couchdb:5984
````

error message:

````
standard_init_linux.go:195: exec user process caused "no such file or directory"
````
