### PR TITLE
Handle specific 'nodedown' error

### DIFF
--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 var (
@@ -104,7 +105,13 @@ func (c *CouchdbClient) getStatsByNodeName(urisByNodeName map[string]string) (ma
 	for name, uri := range urisByNodeName {
 		data, err := c.request("GET", fmt.Sprintf("%s/_stats", uri))
 		if err != nil {
-			return nil, fmt.Errorf("error reading couchdb stats: %v", err)
+			err = fmt.Errorf("error reading couchdb stats: %v", err)
+			if !strings.Contains(err.Error(), "\"error\":\"nodedown\"") {
+				return nil, err
+			}
+
+			glog.Error(fmt.Errorf("continuing despite error: %v", err))
+			continue
 		}
 
 		var stats StatsResponse

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -110,6 +110,7 @@ func (c *CouchdbClient) getStatsByNodeName(urisByNodeName map[string]string) (ma
 				return nil, err
 			}
 
+			delete(urisByNodeName, name)
 			glog.Error(fmt.Errorf("continuing despite error: %v", err))
 			continue
 		}
@@ -121,6 +122,11 @@ func (c *CouchdbClient) getStatsByNodeName(urisByNodeName map[string]string) (ma
 		}
 		statsByNodeName[name] = stats
 	}
+
+	if len(urisByNodeName) == 0 {
+		return nil, fmt.Errorf("all nodes down")
+	}
+
 	return statsByNodeName, nil
 }
 


### PR DESCRIPTION
Fixes #10 

Upon retrieving stats for a specific node, if there is an error it checks if CouchDB returns with the `nodedown` error, meaning stats can't be retrieved from this node. If this specific error is detected, it logs the error and skips the rest of current iteration of the loop instead of returning with the error.

This way, when requesting `/metrics` on the exporter, it will show metrics on all nodes that are up on the cluster, but nothing about the node(s) that is (are) down.

These changes have been tested with our CouchDB cluster.