### PR TITLE
Reset all metrics before collect.

### DIFF
--- a/lib/collector-v1.go
+++ b/lib/collector-v1.go
@@ -47,12 +47,14 @@ func (e *Exporter) collectV1(stats Stats, exposedHttpStatusCodes []string, datab
 
 	activeTasksByNode := make(map[string]ActiveTaskTypes)
 	for _, task := range stats.ActiveTasksResponse {
-		e.activeTasksReplicationLastUpdate.WithLabelValues(
-			task.Node,
-			task.DocId,
-			strconv.FormatBool(task.Continuous),
-			task.Source,
-			task.Target).Set(task.UpdatedOn)
+		if task.Type == "replication" {
+			e.activeTasksReplicationLastUpdate.WithLabelValues(
+				task.Node,
+				task.DocId,
+				strconv.FormatBool(task.Continuous),
+				task.Source,
+				task.Target).Set(task.UpdatedOn)
+		}
 
 		if _, ok := activeTasksByNode[task.Node]; !ok {
 			activeTasksByNode[task.Node] = ActiveTaskTypes{}

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -47,12 +47,14 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, datab
 
 	activeTasksByNode := make(map[string]ActiveTaskTypes)
 	for _, task := range stats.ActiveTasksResponse {
-		e.activeTasksReplicationLastUpdate.WithLabelValues(
-			task.Node,
-			task.DocId,
-			strconv.FormatBool(task.Continuous),
-			task.Source,
-			task.Target).Set(task.UpdatedOn)
+		if task.Type == "replication" {
+			e.activeTasksReplicationLastUpdate.WithLabelValues(
+				task.Node,
+				task.DocId,
+				strconv.FormatBool(task.Continuous),
+				task.Source,
+				task.Target).Set(task.UpdatedOn)
+		}
 
 		if _, ok := activeTasksByNode[task.Node]; !ok {
 			activeTasksByNode[task.Node] = ActiveTaskTypes{}

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -53,6 +53,48 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.activeTasksViewCompaction.Describe(ch)
 	e.activeTasksIndexer.Describe(ch)
 	e.activeTasksReplication.Describe(ch)
+	e.activeTasksReplicationLastUpdate.Describe(ch)
+}
+
+func (e *Exporter) resetAllMetrics() {
+	metrics := []*prometheus.GaugeVec{
+		e.nodeUp,
+
+		e.authCacheHits,
+		e.authCacheMisses,
+		e.databaseReads,
+		e.databaseWrites,
+		e.openDatabases,
+		e.openOsFiles,
+		e.requestTime,
+
+		e.httpdStatusCodes,
+		e.httpdRequestMethods,
+
+		e.clientsRequestingChanges,
+		e.temporaryViewReads,
+		e.requests,
+		e.bulkRequests,
+		e.viewReads,
+
+		e.diskSize,
+		e.dataSize,
+		e.diskSizeOverhead,
+
+		e.activeTasks,
+		e.activeTasksDatabaseCompaction,
+		e.activeTasksViewCompaction,
+		e.activeTasksIndexer,
+		e.activeTasksReplication,
+		e.activeTasksReplicationLastUpdate,
+	}
+	e.resetMetrics(metrics)
+}
+
+func (e *Exporter) resetMetrics(metrics []*prometheus.GaugeVec) {
+	for _, metricVec := range metrics {
+		metricVec.Reset()
+	}
 }
 
 func (e *Exporter) getMonitoredDatabaseNames(candidates []string) ([]string, error) {
@@ -68,6 +110,8 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 		ch <- e.up
 	}
 	defer sendStatus()
+
+	e.resetAllMetrics()
 
 	var databases, err = e.getMonitoredDatabaseNames(e.databases)
 	if err != nil {


### PR DESCRIPTION
This is necessary, because it's not guaranteed that every metric with every label/value combination will be overwritten on subsequent scrapes. Consider missing nodes or stopped replication tasks, which won't show up temporarily.

closes #14
