### PR TITLE
Handle 2.0 prerelease

### DIFF
--- a/couchdb-exporter_test.go
+++ b/couchdb-exporter_test.go
@@ -134,6 +134,10 @@ func TestCouchdbStatsV2(t *testing.T) {
 	performCouchdbStatsTest(t, "v2", 79, 4712, 58570)
 }
 
+func TestCouchdbStatsV2Prerelease(t *testing.T) {
+	performCouchdbStatsTest(t, "v2-pre", 79, 4712, 58570)
+}
+
 func TestCouchdbStatsV1Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")

--- a/couchdb-exporter_test.go
+++ b/couchdb-exporter_test.go
@@ -10,12 +10,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
 	"github.com/gesellix/couchdb-cluster-config/pkg"
 	"github.com/gesellix/couchdb-prometheus-exporter/lib"
 	"github.com/gesellix/couchdb-prometheus-exporter/testutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
-	"time"
 )
 
 type Handler func(w http.ResponseWriter, r *http.Request)
@@ -212,7 +213,7 @@ func TestCouchdbStatsV1Integration(t *testing.T) {
 	}
 }
 
-func awaitMembership(t *testing.T, basicAuth lib.BasicAuth) (func(address string) (bool, error)) {
+func awaitMembership(t *testing.T, basicAuth lib.BasicAuth) func(address string) (bool, error) {
 	time.Sleep(5 * time.Second)
 
 	return func(address string) (bool, error) {

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -4,12 +4,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/hashicorp/go-version"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
-	"io"
+
+	"github.com/golang/glog"
 )
 
 type BasicAuth struct {
@@ -50,22 +51,18 @@ func (c *CouchdbClient) getServerVersion() (string, error) {
 }
 
 func (c *CouchdbClient) isCouchDbV2() (bool, error) {
-	clusteredCouch, err := version.NewConstraint(">= 2.0")
-	if err != nil {
-		return false, err
-	}
-
 	serverVersion, err := c.getServerVersion()
 	if err != nil {
 		return false, err
 	}
 
-	couchDbVersion, err := version.NewVersion(serverVersion)
+	versionParts := strings.Split(serverVersion, ".")
+	major, err := strconv.Atoi(versionParts[0])
 	if err != nil {
 		return false, err
 	}
 
-	return clusteredCouch.Check(couchDbVersion), nil
+	return major >= 2, nil
 }
 
 func (c *CouchdbClient) GetNodeNames() ([]string, error) {

--- a/testdata/active-tasks-v2-pre.json
+++ b/testdata/active-tasks-v2-pre.json
@@ -1,0 +1,1 @@
+active-tasks-v2.json

--- a/testdata/couchdb-membership-response-v2-pre.json
+++ b/testdata/couchdb-membership-response-v2-pre.json
@@ -1,0 +1,1 @@
+couchdb-membership-response-v2.json

--- a/testdata/couchdb-stats-response-v2-pre.json
+++ b/testdata/couchdb-stats-response-v2-pre.json
@@ -1,0 +1,1 @@
+couchdb-stats-response-v2.json

--- a/testdata/couchdb-v2-pre.json
+++ b/testdata/couchdb-v2-pre.json
@@ -1,0 +1,8 @@
+{
+  "couchdb": "Welcome",
+  "version": "2.2.0-302bd8b",
+  "features": ["scheduler"],
+  "vendor": {
+    "name": "The Apache Software Foundation"
+  }
+}

--- a/testdata/example-meta-v2-pre.json
+++ b/testdata/example-meta-v2-pre.json
@@ -1,0 +1,1 @@
+example-meta-v2.json


### PR DESCRIPTION
I'm running a prerelease version of CouchDB, to work around some bugs in the latest stable release.  Unfortunately, https://github.com/hashicorp/go-version misidentifies `"2.2.0-sha1"` as not matching `">= 2.0"`.  And so `couchdb-prometheus-exporter` misidentifies my server as CouchDB 1.x.

I've simplified the version check to simply match on the major version >= 2, and I've also submitted an issue at hashicorp/go-version#36.