### PR TITLE
Added a flag to ignore replications updated_on

### DIFF
--- a/couchdb-exporter.go
+++ b/couchdb-exporter.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"fmt"
 	goflag "flag"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+
 	"github.com/gesellix/couchdb-prometheus-exporter/glogadapt"
 	"github.com/gesellix/couchdb-prometheus-exporter/lib"
 	"github.com/golang/glog"
@@ -15,13 +16,14 @@ import (
 )
 
 type exporterConfigType struct {
-	listenAddress   string
-	metricsEndpoint string
-	couchdbURI      string
-	couchdbUsername string
-	couchdbPassword string
-	couchdbInsecure bool
-	databases       string
+	listenAddress      string
+	metricsEndpoint    string
+	couchdbURI         string
+	couchdbUsername    string
+	couchdbPassword    string
+	couchdbInsecure    bool
+	couchdbReplsUpdate bool
+	databases          string
 }
 
 var exporterConfig exporterConfigType
@@ -34,6 +36,7 @@ func init() {
 	flag.StringVar(&exporterConfig.couchdbUsername, "couchdb.username", "", "Basic auth username for the CouchDB instance")
 	flag.StringVar(&exporterConfig.couchdbPassword, "couchdb.password", "", "Basic auth password for the CouchDB instance")
 	flag.BoolVar(&exporterConfig.couchdbInsecure, "couchdb.insecure", true, "Ignore server certificate if using https")
+	flag.BoolVar(&exporterConfig.couchdbReplsUpdate, "couchdb.replsupdate", true, "Report on each replication task's updated_on.")
 	flag.StringVar(&exporterConfig.databases, "databases", "", "Comma separated list of database names")
 
 	flag.BoolVar(&glogadapt.Logging.ToStderr, "logtostderr", false, "log to standard error instead of files")
@@ -63,7 +66,9 @@ func main() {
 			Username: *&exporterConfig.couchdbUsername,
 			Password: *&exporterConfig.couchdbPassword},
 		databases,
-		*&exporterConfig.couchdbInsecure)
+		*&exporterConfig.couchdbInsecure,
+		*&exporterConfig.couchdbReplsUpdate,
+	)
 	prometheus.MustRegister(exporter)
 
 	http.Handle(*&exporterConfig.metricsEndpoint, promhttp.Handler())

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -48,7 +48,7 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, datab
 
 	activeTasksByNode := make(map[string]ActiveTaskTypes)
 	for _, task := range stats.ActiveTasksResponse {
-		if task.Type == "replication" {
+		if e.replsUpdate && task.Type == "replication" {
 			e.activeTasksReplicationLastUpdate.WithLabelValues(
 				task.Node,
 				task.DocId,

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -10,9 +10,10 @@ const (
 )
 
 type Exporter struct {
-	client    *CouchdbClient
-	databases []string
-	mutex     sync.RWMutex
+	client      *CouchdbClient
+	databases   []string
+	replsUpdate bool
+	mutex       sync.RWMutex
 
 	up       prometheus.Gauge
 	nodeUp   *prometheus.GaugeVec
@@ -47,11 +48,12 @@ type Exporter struct {
 	activeTasksReplicationLastUpdate *prometheus.GaugeVec
 }
 
-func NewExporter(uri string, basicAuth BasicAuth, databases []string, insecure bool) *Exporter {
+func NewExporter(uri string, basicAuth BasicAuth, databases []string, insecure, replsUpdate bool) *Exporter {
 
 	return &Exporter{
-		client:    NewCouchdbClient(uri, basicAuth, insecure),
-		databases: databases,
+		client:      NewCouchdbClient(uri, basicAuth, insecure),
+		databases:   databases,
+		replsUpdate: replsUpdate,
 
 		up: prometheus.NewGauge(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
I'm running servers which have tens of thousands of unique replication documents, hundreds of which are running at any one point in time (using 2.1's scheduler).  It might occasionally be useful to know the last `updated_on`, but I can get that data just as easily via CouchDB's `/_scheduler/docs` API: http://docs.couchdb.org/en/2.1.0/api/server/common.html#scheduler-docs, and don't need it to be tracked (and taking disk space) by prometheus.  So I added a `-couchdb.replsupdate=true` boolean flag, which can be used to opt-out.