### PR TITLE
Add databases_total metric

### DIFF
--- a/lib/collector-v1.go
+++ b/lib/collector-v1.go
@@ -6,6 +6,8 @@ import (
 )
 
 func (e *Exporter) collectV1(stats Stats, exposedHttpStatusCodes []string, databases []string) error {
+	e.totalDatabases.Set(float64(stats.TotalDatabases))
+
 	for name, nodeStats := range stats.StatsByNodeName {
 		//fmt.Printf("%s -> %v\n", name, stats)
 		//glog.Info(fmt.Sprintf("name: %s -> stats: %v\n", name, stats))

--- a/lib/collector-v1.go
+++ b/lib/collector-v1.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (e *Exporter) collectV1(stats Stats, exposedHttpStatusCodes []string, databases []string) error {
-	e.totalDatabases.Set(float64(stats.TotalDatabases))
+	e.databasesTotal.Set(float64(stats.DatabasesTotal))
 
 	for name, nodeStats := range stats.StatsByNodeName {
 		//fmt.Printf("%s -> %v\n", name, stats)

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -6,6 +6,8 @@ import (
 )
 
 func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, databases []string) error {
+	e.totalDatabases.Set(float64(stats.TotalDatabases))
+
 	for name, nodeStats := range stats.StatsByNodeName {
 		//fmt.Printf("%s -> %v\n", name, stats)
 		//glog.Info(fmt.Sprintf("name: %s -> stats: %v\n", name, stats))

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, databases []string) error {
-	e.totalDatabases.Set(float64(stats.TotalDatabases))
+	e.databasesTotal.Set(float64(stats.DatabasesTotal))
 
 	for name, nodeStats := range stats.StatsByNodeName {
 		//fmt.Printf("%s -> %v\n", name, stats)

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -25,6 +25,7 @@ type ActiveTaskTypesByNodeName map[string]ActiveTaskTypes
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.up.Desc()
+	e.totalDatabases.Describe(ch)
 	e.nodeUp.Describe(ch)
 	e.nodeInfo.Describe(ch)
 
@@ -132,6 +133,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 		e.collectV1(stats, exposedHttpStatusCodes, databases)
 	}
 
+	e.totalDatabases.Collect(ch)
 	e.nodeUp.Collect(ch)
 	e.nodeInfo.Collect(ch)
 

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -25,7 +25,7 @@ type ActiveTaskTypesByNodeName map[string]ActiveTaskTypes
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.up.Desc()
-	e.totalDatabases.Describe(ch)
+	e.databasesTotal.Describe(ch)
 	e.nodeUp.Describe(ch)
 	e.nodeInfo.Describe(ch)
 
@@ -133,7 +133,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 		e.collectV1(stats, exposedHttpStatusCodes, databases)
 	}
 
-	e.totalDatabases.Collect(ch)
+	e.databasesTotal.Collect(ch)
 	e.nodeUp.Collect(ch)
 	e.nodeInfo.Collect(ch)
 

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -162,7 +162,7 @@ func (c *CouchdbClient) getStats(databases []string) (Stats, error) {
 		}
 		return Stats{
 			StatsByNodeName:       nodeStats,
-			TotalDatabases:        len(databasesList),
+			DatabasesTotal:        len(databasesList),
 			DatabaseStatsByDbName: databaseStats,
 			ActiveTasksResponse:   activeTasks,
 			ApiVersion:            "2"}, nil
@@ -188,7 +188,7 @@ func (c *CouchdbClient) getStats(databases []string) (Stats, error) {
 		}
 		return Stats{
 			StatsByNodeName:       nodeStats,
-			TotalDatabases:        len(databasesList),
+			DatabasesTotal:        len(databasesList),
 			DatabaseStatsByDbName: databaseStats,
 			ActiveTasksResponse:   activeTasks,
 			ApiVersion:            "1"}, nil

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-version"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"io"
 )
 
 type BasicAuth struct {
@@ -156,8 +156,13 @@ func (c *CouchdbClient) getStats(databases []string) (Stats, error) {
 		if err != nil {
 			return Stats{}, err
 		}
+		databasesList, err := c.getDatabaseList()
+		if err != nil {
+			return Stats{}, err
+		}
 		return Stats{
 			StatsByNodeName:       nodeStats,
+			TotalDatabases:        len(databasesList),
 			DatabaseStatsByDbName: databaseStats,
 			ActiveTasksResponse:   activeTasks,
 			ApiVersion:            "2"}, nil
@@ -177,8 +182,13 @@ func (c *CouchdbClient) getStats(databases []string) (Stats, error) {
 		if err != nil {
 			return Stats{}, err
 		}
+		databasesList, err := c.getDatabaseList()
+		if err != nil {
+			return Stats{}, err
+		}
 		return Stats{
 			StatsByNodeName:       nodeStats,
+			TotalDatabases:        len(databasesList),
 			DatabaseStatsByDbName: databaseStats,
 			ActiveTasksResponse:   activeTasks,
 			ApiVersion:            "1"}, nil

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -120,6 +120,7 @@ type ActiveTasksResponse []ActiveTask
 
 type Stats struct {
 	StatsByNodeName       map[string]StatsResponse
+	TotalDatabases        int
 	DatabaseStatsByDbName DatabaseStatsByDbName
 	ActiveTasksResponse   ActiveTasksResponse
 	ApiVersion            string

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -120,7 +120,7 @@ type ActiveTasksResponse []ActiveTask
 
 type Stats struct {
 	StatsByNodeName       map[string]StatsResponse
-	TotalDatabases        int
+	DatabasesTotal        int
 	DatabaseStatsByDbName DatabaseStatsByDbName
 	ActiveTasksResponse   ActiveTasksResponse
 	ApiVersion            string

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -14,9 +14,10 @@ type Exporter struct {
 	databases []string
 	mutex     sync.RWMutex
 
-	up       prometheus.Gauge
-	nodeUp   *prometheus.GaugeVec
-	nodeInfo *prometheus.GaugeVec
+	up             prometheus.Gauge
+	totalDatabases prometheus.Gauge
+	nodeUp         *prometheus.GaugeVec
+	nodeInfo       *prometheus.GaugeVec
 
 	authCacheHits   *prometheus.GaugeVec
 	authCacheMisses *prometheus.GaugeVec
@@ -59,6 +60,13 @@ func NewExporter(uri string, basicAuth BasicAuth, databases []string, insecure b
 				Subsystem: "httpd",
 				Name:      "up",
 				Help:      "Was the last query of CouchDB stats successful.",
+			}),
+		totalDatabases: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "httpd",
+				Name:      "total_databases",
+				Help:      "Total number of databases in the cluster",
 			}),
 		nodeUp: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -15,7 +15,7 @@ type Exporter struct {
 	mutex     sync.RWMutex
 
 	up             prometheus.Gauge
-	totalDatabases prometheus.Gauge
+	databasesTotal prometheus.Gauge
 	nodeUp         *prometheus.GaugeVec
 	nodeInfo       *prometheus.GaugeVec
 
@@ -61,11 +61,11 @@ func NewExporter(uri string, basicAuth BasicAuth, databases []string, insecure b
 				Name:      "up",
 				Help:      "Was the last query of CouchDB stats successful.",
 			}),
-		totalDatabases: prometheus.NewGauge(
+		databasesTotal: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Subsystem: "httpd",
-				Name:      "total_databases",
+				Name:      "databases_total",
 				Help:      "Total number of databases in the cluster",
 			}),
 		nodeUp: prometheus.NewGaugeVec(

--- a/testdata/all-dbs.json
+++ b/testdata/all-dbs.json
@@ -1,0 +1,7 @@
+[
+   "_users",
+   "contacts",
+   "docs",
+   "invoices",
+   "locations"
+]


### PR DESCRIPTION
Our team would like to track the evolution of the total number of databases over time.
This pull requests adds a `total_databases` metric (full name `couchdb_httpd_total_databases`) exposing the total number of databases in the cluster.
This should be compatible with both v1 and v2, according to CouchDB's docs.