### PR TITLE
V2 metrics

### DIFF
--- a/couchdb-exporter_test.go
+++ b/couchdb-exporter_test.go
@@ -170,7 +170,7 @@ func TestCouchdbStatsV1(t *testing.T) {
 }
 
 func TestCouchdbStatsV2(t *testing.T) {
-	performCouchdbStatsTest(t, "v2", 106, 4712, 58570, 15)
+	performCouchdbStatsTest(t, "v2", 228, 4712, 58570, 17)
 }
 
 func TestCouchdbStatsV1Integration(t *testing.T) {

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -26,6 +26,22 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 			e.couchLog.WithLabelValues(level, name).Set(nodeStats.CouchLog.Level[level].Value)
 		}
 
+		for _, metric := range exposedWorkerMetrics {
+			e.fabricWorker.WithLabelValues(metric, name).Set(nodeStats.Fabric.Worker[metric].Value)
+		}
+
+		for _, metric := range exposedOpenShardMetrics {
+			e.fabricOpenShard.WithLabelValues(metric, name).Set(nodeStats.Fabric.OpenShard[metric].Value)
+		}
+
+		for _, metric := range exposedReadRepairMetrics {
+			e.fabricReadRepairs.WithLabelValues(metric, name).Set(nodeStats.Fabric.ReadRepairs[metric].Value)
+		}
+
+		for _, metric := range exposedDocUpdateMetrics {
+			e.fabricDocUpdate.WithLabelValues(metric, name).Set(nodeStats.Fabric.DocUpdate[metric].Value)
+		}
+
 		for _, code := range exposedHttpStatusCodes {
 			if _, ok := nodeStats.Couchdb.HttpdStatusCodes[code]; ok {
 				e.httpdStatusCodes.WithLabelValues(code, name).Set(nodeStats.Couchdb.HttpdStatusCodes[code].Value)

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -34,7 +34,7 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 			e.fabricOpenShard.WithLabelValues(metric, name).Set(nodeStats.Fabric.OpenShard[metric].Value)
 		}
 
-		for _, metric := range exposedReadRepairMetrics {
+		for _, metric := range exposedExitState {
 			e.fabricReadRepairs.WithLabelValues(metric, name).Set(nodeStats.Fabric.ReadRepairs[metric].Value)
 		}
 
@@ -60,6 +60,35 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 		e.requests.WithLabelValues(name).Set(nodeStats.Couchdb.Httpd.Requests.Value)
 		e.temporaryViewReads.WithLabelValues(name).Set(nodeStats.Couchdb.Httpd.TemporaryViewReads.Value)
 		e.viewReads.WithLabelValues(name).Set(nodeStats.Couchdb.Httpd.ViewReads.Value)
+
+		e.couchReplicatorChangesReadFailures.WithLabelValues(name).Set(nodeStats.CouchReplicator.ChangesReadFailures.Value)
+		e.couchReplicatorChangesReaderDeaths.WithLabelValues(name).Set(nodeStats.CouchReplicator.ChangesReaderDeaths.Value)
+		e.couchReplicatorChangesManagerDeaths.WithLabelValues(name).Set(nodeStats.CouchReplicator.ChangesManagerDeaths.Value)
+		e.couchReplicatorChangesQueueDeaths.WithLabelValues(name).Set(nodeStats.CouchReplicator.ChangesQueueDeaths.Value)
+		for _, metric := range exposedExitState {
+			e.couchReplicatorCheckpoints.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.Checkpoints[metric].Value)
+		}
+		e.couchReplicatorFailedStarts.WithLabelValues(name).Set(nodeStats.CouchReplicator.FailedStarts.Value)
+		e.couchReplicatorRequests.WithLabelValues(name).Set(nodeStats.CouchReplicator.Requests.Value)
+		for _, metric := range exposedExitState {
+			e.couchReplicatorResponses.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.Responses[metric].Value)
+		}
+		for _, metric := range exposedExitState {
+			e.couchReplicatorStreamResponses.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.StreamResponses[metric].Value)
+		}
+		e.couchReplicatorWorkerDeaths.WithLabelValues(name).Set(nodeStats.CouchReplicator.WorkerDeaths.Value)
+		e.couchReplicatorWorkersStarted.WithLabelValues(name).Set(nodeStats.CouchReplicator.WorkersStarted.Value)
+		e.couchReplicatorClusterIsStable.WithLabelValues(name).Set(nodeStats.CouchReplicator.ClusterIsStable.Value)
+		e.couchReplicatorDbScans.WithLabelValues(name).Set(nodeStats.CouchReplicator.DbScans.Value)
+		for _, metric := range exposedReplicatorDocs {
+			e.couchReplicatorDocs.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.Docs[metric].Value)
+		}
+		for _, metric := range exposedReplicatorJobs {
+			e.couchReplicatorJobs.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.Jobs[metric].Value)
+		}
+		for _, metric := range exposedReplicatorConnection {
+			e.couchReplicatorConnection.WithLabelValues(metric, name).Set(nodeStats.CouchReplicator.Connection[metric].Value)
+		}
 	}
 
 	for _, dbName := range collectorConfig.ObservedDatabases {

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -9,8 +9,8 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 	e.databasesTotal.Set(float64(stats.DatabasesTotal))
 
 	for name, nodeStats := range stats.StatsByNodeName {
-		//fmt.Printf("%s -> %v\n", name, stats)
-		//glog.Info(fmt.Sprintf("name: %s -> stats: %v\n", name, stats))
+		// fmt.Printf("%s -> %v\n", name, stats)
+		// glog.Info(fmt.Sprintf("name: %s -> stats: %v\n", name, stats))
 		e.nodeUp.WithLabelValues(name).Set(nodeStats.Up)
 		e.nodeInfo.WithLabelValues(name, nodeStats.NodeInfo.Version, nodeStats.NodeInfo.Vendor.Name).Set(1)
 
@@ -21,6 +21,10 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 		e.openDatabases.WithLabelValues(name).Set(nodeStats.Couchdb.OpenDatabases.Value)
 		e.openOsFiles.WithLabelValues(name).Set(nodeStats.Couchdb.OpenOsFiles.Value)
 		e.requestTime.WithLabelValues(name).Set(nodeStats.Couchdb.RequestTime.Value.Median)
+
+		for _, level := range exposedLogLevels {
+			e.couchLog.WithLabelValues(level, name).Set(nodeStats.CouchLog.Level[level].Value)
+		}
 
 		for _, code := range exposedHttpStatusCodes {
 			if _, ok := nodeStats.Couchdb.HttpdStatusCodes[code]; ok {
@@ -66,7 +70,7 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 					for _, dbRangeSeq := range dbUpdateSeq {
 						if viewRangeSeq.Range[0].Cmp(dbRangeSeq.Range[0]) == 0 {
 							age := dbRangeSeq.Seq - viewRangeSeq.Seq
-							//glog.Infof("dbRangeSeq.Seq %d, viewRangeSeq.Seq %d, age %d", dbRangeSeq.Seq, viewRangeSeq.Seq, age)
+							// glog.Infof("dbRangeSeq.Seq %d, viewRangeSeq.Seq %d, age %d", dbRangeSeq.Seq, viewRangeSeq.Seq, age)
 							e.viewStaleness.WithLabelValues(
 								dbName,
 								designDoc,

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -139,5 +139,16 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 		e.activeTasksReplication.WithLabelValues(nodeName).Set(tasks.Replication)
 	}
 
+	for nodeName, metric := range stats.SystemByNodeName {
+		e.nodeMemoryOther.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Other)
+		e.nodeMemoryAtom.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Atom)
+		e.nodeMemoryAtomUsed.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.AtomUsed)
+		e.nodeMemoryProcesses.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Processes)
+		e.nodeMemoryProcessesUsed.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.ProcessesUsed)
+		e.nodeMemoryBinary.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Binary)
+		e.nodeMemoryCode.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Code)
+		e.nodeMemoryEts.WithLabelValues(nodeName).Set(metric.MemoryStatsResponse.Ets)
+	}
+
 	return nil
 }

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -32,7 +32,7 @@ var (
 	exposedOpenShardMetrics = []string{
 		"timeout"}
 
-	exposedReadRepairMetrics = []string{
+	exposedExitState = []string{
 		"success",
 		"failure"}
 
@@ -40,6 +40,34 @@ var (
 		"errors",
 		"mismatched_errors",
 		"write_quorum_errors"}
+
+	exposedReplicatorDocs = []string{
+		"dbs_created",
+		"dbs_deleted",
+		"dbs_found",
+		"dbs_changes",
+		"failed_state_updates",
+		"completed_state_updates"}
+
+	exposedReplicatorJobs = []string{
+		"adds",
+		"duplicate_adds",
+		"removes",
+		"starts",
+		"stops",
+		"crashes",
+		"running",
+		"pending",
+		"crashed",
+		"total"}
+
+	exposedReplicatorConnection = []string{
+		"acquires",
+		"creates",
+		"releases",
+		"owner_crashes",
+		"worker_crashes",
+		"closes"}
 )
 
 type CollectorConfig struct {
@@ -118,6 +146,23 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.fabricReadRepairs.Describe(ch)
 	e.fabricDocUpdate.Describe(ch)
 
+	e.couchReplicatorChangesReadFailures.Describe(ch)
+	e.couchReplicatorChangesReaderDeaths.Describe(ch)
+	e.couchReplicatorChangesManagerDeaths.Describe(ch)
+	e.couchReplicatorChangesQueueDeaths.Describe(ch)
+	e.couchReplicatorCheckpoints.Describe(ch)
+	e.couchReplicatorFailedStarts.Describe(ch)
+	e.couchReplicatorRequests.Describe(ch)
+	e.couchReplicatorResponses.Describe(ch)
+	e.couchReplicatorStreamResponses.Describe(ch)
+	e.couchReplicatorWorkerDeaths.Describe(ch)
+	e.couchReplicatorWorkersStarted.Describe(ch)
+	e.couchReplicatorClusterIsStable.Describe(ch)
+	e.couchReplicatorDbScans.Describe(ch)
+	e.couchReplicatorDocs.Describe(ch)
+	e.couchReplicatorJobs.Describe(ch)
+	e.couchReplicatorConnection.Describe(ch)
+
 	e.nodeMemoryOther.Describe(ch)
 	e.nodeMemoryAtom.Describe(ch)
 	e.nodeMemoryAtomUsed.Describe(ch)
@@ -176,6 +221,23 @@ func (e *Exporter) resetAllMetrics() {
 		e.fabricOpenShard,
 		e.fabricReadRepairs,
 		e.fabricDocUpdate,
+
+		e.couchReplicatorChangesReadFailures,
+		e.couchReplicatorChangesReaderDeaths,
+		e.couchReplicatorChangesManagerDeaths,
+		e.couchReplicatorChangesQueueDeaths,
+		e.couchReplicatorCheckpoints,
+		e.couchReplicatorFailedStarts,
+		e.couchReplicatorRequests,
+		e.couchReplicatorResponses,
+		e.couchReplicatorStreamResponses,
+		e.couchReplicatorWorkerDeaths,
+		e.couchReplicatorWorkersStarted,
+		e.couchReplicatorClusterIsStable,
+		e.couchReplicatorDbScans,
+		e.couchReplicatorDocs,
+		e.couchReplicatorJobs,
+		e.couchReplicatorConnection,
 
 		e.nodeMemoryOther,
 		e.nodeMemoryAtom,
@@ -284,6 +346,23 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 	e.fabricOpenShard.Collect(ch)
 	e.fabricReadRepairs.Collect(ch)
 	e.fabricDocUpdate.Collect(ch)
+
+	e.couchReplicatorChangesReadFailures.Collect(ch)
+	e.couchReplicatorChangesReaderDeaths.Collect(ch)
+	e.couchReplicatorChangesManagerDeaths.Collect(ch)
+	e.couchReplicatorChangesQueueDeaths.Collect(ch)
+	e.couchReplicatorCheckpoints.Collect(ch)
+	e.couchReplicatorFailedStarts.Collect(ch)
+	e.couchReplicatorRequests.Collect(ch)
+	e.couchReplicatorResponses.Collect(ch)
+	e.couchReplicatorStreamResponses.Collect(ch)
+	e.couchReplicatorWorkerDeaths.Collect(ch)
+	e.couchReplicatorWorkersStarted.Collect(ch)
+	e.couchReplicatorClusterIsStable.Collect(ch)
+	e.couchReplicatorDbScans.Collect(ch)
+	e.couchReplicatorDocs.Collect(ch)
+	e.couchReplicatorJobs.Collect(ch)
+	e.couchReplicatorConnection.Collect(ch)
 
 	e.nodeMemoryOther.Collect(ch)
 	e.nodeMemoryAtom.Collect(ch)

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -25,6 +25,21 @@ var (
 		"info",
 		"notice",
 		"warning"}
+
+	exposedWorkerMetrics = []string{
+		"timeout"}
+
+	exposedOpenShardMetrics = []string{
+		"timeout"}
+
+	exposedReadRepairMetrics = []string{
+		"success",
+		"failure"}
+
+	exposedDocUpdateMetrics = []string{
+		"errors",
+		"mismatched_errors",
+		"write_quorum_errors"}
 )
 
 type CollectorConfig struct {
@@ -98,6 +113,11 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 
 	e.couchLog.Describe(ch)
 
+	e.fabricWorker.Describe(ch)
+	e.fabricOpenShard.Describe(ch)
+	e.fabricReadRepairs.Describe(ch)
+	e.fabricDocUpdate.Describe(ch)
+
 	e.nodeMemoryOther.Describe(ch)
 	e.nodeMemoryAtom.Describe(ch)
 	e.nodeMemoryAtomUsed.Describe(ch)
@@ -151,6 +171,11 @@ func (e *Exporter) resetAllMetrics() {
 		e.activeTasksReplicationLastUpdate,
 
 		e.couchLog,
+
+		e.fabricWorker,
+		e.fabricOpenShard,
+		e.fabricReadRepairs,
+		e.fabricDocUpdate,
 
 		e.nodeMemoryOther,
 		e.nodeMemoryAtom,
@@ -254,6 +279,11 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 	e.activeTasksReplicationLastUpdate.Collect(ch)
 
 	e.couchLog.Collect(ch)
+
+	e.fabricWorker.Collect(ch)
+	e.fabricOpenShard.Collect(ch)
+	e.fabricReadRepairs.Collect(ch)
+	e.fabricDocUpdate.Collect(ch)
 
 	e.nodeMemoryOther.Collect(ch)
 	e.nodeMemoryAtom.Collect(ch)

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -15,6 +15,16 @@ var (
 		"301", "304",
 		"400", "401", "403", "404", "405", "409", "412",
 		"500"}
+
+	exposedLogLevels = []string{
+		"alert",
+		"critical",
+		"debug",
+		"emergency",
+		"error",
+		"info",
+		"notice",
+		"warning"}
 )
 
 type CollectorConfig struct {
@@ -73,6 +83,8 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.activeTasksReplication.Describe(ch)
 	e.activeTasksReplicationLastUpdate.Describe(ch)
 
+	e.couchLog.Describe(ch)
+
 	e.viewStaleness.Describe(ch)
 
 	e.schedulerJobs.Describe(ch)
@@ -115,6 +127,8 @@ func (e *Exporter) resetAllMetrics() {
 		e.activeTasksIndexer,
 		e.activeTasksReplication,
 		e.activeTasksReplicationLastUpdate,
+
+		e.couchLog,
 
 		e.viewStaleness,
 
@@ -207,6 +221,8 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 	e.activeTasksIndexer.Collect(ch)
 	e.activeTasksReplication.Collect(ch)
 	e.activeTasksReplicationLastUpdate.Collect(ch)
+
+	e.couchLog.Collect(ch)
 
 	e.viewStaleness.Collect(ch)
 

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -44,6 +44,19 @@ type ActiveTaskTypes struct {
 
 type ActiveTaskTypesByNodeName map[string]ActiveTaskTypes
 
+type MemoryMetrics struct {
+	Other         float64
+	Atom          float64
+	AtomUsed      float64
+	Processes     float64
+	ProcessesUsed float64
+	Binary        float64
+	Code          float64
+	Ets           float64
+}
+
+type MemoryTypesByNodeName map[string]MemoryMetrics
+
 // Describe describes all the metrics ever exported by the couchdb exporter. It
 // implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
@@ -84,6 +97,15 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.activeTasksReplicationLastUpdate.Describe(ch)
 
 	e.couchLog.Describe(ch)
+
+	e.nodeMemoryOther.Describe(ch)
+	e.nodeMemoryAtom.Describe(ch)
+	e.nodeMemoryAtomUsed.Describe(ch)
+	e.nodeMemoryProcesses.Describe(ch)
+	e.nodeMemoryProcessesUsed.Describe(ch)
+	e.nodeMemoryBinary.Describe(ch)
+	e.nodeMemoryCode.Describe(ch)
+	e.nodeMemoryEts.Describe(ch)
 
 	e.viewStaleness.Describe(ch)
 
@@ -129,6 +151,15 @@ func (e *Exporter) resetAllMetrics() {
 		e.activeTasksReplicationLastUpdate,
 
 		e.couchLog,
+
+		e.nodeMemoryOther,
+		e.nodeMemoryAtom,
+		e.nodeMemoryAtomUsed,
+		e.nodeMemoryProcesses,
+		e.nodeMemoryProcessesUsed,
+		e.nodeMemoryBinary,
+		e.nodeMemoryCode,
+		e.nodeMemoryEts,
 
 		e.viewStaleness,
 
@@ -223,6 +254,15 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 	e.activeTasksReplicationLastUpdate.Collect(ch)
 
 	e.couchLog.Collect(ch)
+
+	e.nodeMemoryOther.Collect(ch)
+	e.nodeMemoryAtom.Collect(ch)
+	e.nodeMemoryAtomUsed.Collect(ch)
+	e.nodeMemoryProcesses.Collect(ch)
+	e.nodeMemoryProcessesUsed.Collect(ch)
+	e.nodeMemoryBinary.Collect(ch)
+	e.nodeMemoryCode.Collect(ch)
+	e.nodeMemoryEts.Collect(ch)
 
 	e.viewStaleness.Collect(ch)
 

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -160,7 +160,6 @@ func (c *CouchdbClient) getSystemByNodeName(urisByNodeName map[string]string) (m
 
 		SystemByNodeName[name] = stats
 	}
-	fmt.Println("DEBUG: stats - ", SystemByNodeName)
 
 	if len(urisByNodeName) == 0 {
 		return nil, fmt.Errorf("all nodes down")

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -4,12 +4,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/hashicorp/go-version"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-version"
 )
 
 type BasicAuth struct {
@@ -80,9 +81,9 @@ func (c *CouchdbClient) GetNodeNames() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	//for i, name := range membership.ClusterNodes {
-	//	glog.Infof("node[%d]: %s\n", i, name)
-	//}
+	// for i, name := range membership.ClusterNodes {
+	// 	glog.Infof("node[%d]: %s\n", i, name)
+	// }
 	return membership.ClusterNodes, nil
 }
 
@@ -260,7 +261,7 @@ func (c *CouchdbClient) enhanceWithViewUpdateSeq(dbStatsByDbName map[string]Data
 		for _, row := range designDocs.Rows {
 			updateSeqByView := make(ViewStats)
 			for viewName := range row.Doc.Views {
-				//glog.Infof("/%s/%s/_view/%s\n", dbName, row.Doc.Id, viewName)
+				// glog.Infof("/%s/%s/_view/%s\n", dbName, row.Doc.Id, viewName)
 				query = strings.Join([]string{
 					"stale=ok",
 					"update=false",
@@ -375,7 +376,6 @@ func (c *CouchdbClient) Request(method string, uri string, body io.Reader) (resp
 	if err != nil {
 		return nil, err
 	}
-
 	return respData, nil
 }
 

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -181,6 +181,22 @@ type SchedulerJobsResponse struct {
 	} `json:"jobs"`
 }
 
+type MemoryStats struct {
+	// v2.x api
+	Other         float64 `json:"other"`
+	Atom          float64 `json:"atom"`
+	AtomUsed      float64 `json:"atom_used"`
+	Processes     float64 `json:"processes"`
+	ProcessesUsed float64 `json:"processes_used"`
+	Binary        float64 `json:"binary"`
+	Code          float64 `json:"code"`
+	Ets           float64 `json:"ets"`
+}
+
+type SystemResponse struct {
+	MemoryStatsResponse MemoryStats `json:"memory"`
+}
+
 type Stats struct {
 	StatsByNodeName       map[string]StatsResponse
 	DatabasesTotal        int
@@ -188,5 +204,6 @@ type Stats struct {
 	ActiveTasksResponse   ActiveTasksResponse
 	// SchedulerJobsResponse: CouchDB 2.x+ only
 	SchedulerJobsResponse SchedulerJobsResponse
+	SystemByNodeName      map[string]SystemResponse
 	ApiVersion            string
 }

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -97,6 +97,13 @@ type LogLevel struct {
 	Level map[string]Counter `json:"level"`
 }
 
+type Fabric struct {
+	Worker      map[string]Counter `json:"worker"`
+	OpenShard   map[string]Counter `json:"open_shard"`
+	ReadRepairs map[string]Counter `json:"read_repairs"`
+	DocUpdate   map[string]Counter `json:"doc_update"`
+}
+
 type StatsResponse struct {
 	Couchdb  CouchdbStats `json:"couchdb"`
 	Up       float64      `json:"-"`
@@ -107,6 +114,7 @@ type StatsResponse struct {
 	HttpdStatusCodes    HttpdStatusCodes    `json:"httpd_status_codes"`
 	// v2.x api
 	CouchLog LogLevel `json:"couch_log"`
+	Fabric   Fabric   `json:"fabric"`
 }
 
 type View map[string]interface{}

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -93,6 +93,10 @@ type NodeInfo struct {
 	Version  string       `json:"version"`
 }
 
+type LogLevel struct {
+	Level map[string]Counter `json:"level"`
+}
+
 type StatsResponse struct {
 	Couchdb  CouchdbStats `json:"couchdb"`
 	Up       float64      `json:"-"`
@@ -101,6 +105,8 @@ type StatsResponse struct {
 	Httpd               Httpd               `json:"httpd"`
 	HttpdRequestMethods HttpdRequestMethods `json:"httpd_request_methods"`
 	HttpdStatusCodes    HttpdStatusCodes    `json:"httpd_status_codes"`
+	// v2.x api
+	CouchLog LogLevel `json:"couch_log"`
 }
 
 type View map[string]interface{}

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -104,6 +104,25 @@ type Fabric struct {
 	DocUpdate   map[string]Counter `json:"doc_update"`
 }
 
+type CouchReplicator struct {
+	ChangesReadFailures  Counter            `json:"changes_read_failures"`
+	ChangesReaderDeaths  Counter            `json:"changes_reader_deaths"`
+	ChangesManagerDeaths Counter            `json:"changes_manager_deaths"`
+	ChangesQueueDeaths   Counter            `json:"changes_queue_deaths"`
+	Checkpoints          map[string]Counter `json:"checkpoints"`
+	FailedStarts         Counter            `json:"failed_starts"`
+	Requests             Counter            `json:"requests"`
+	Responses            map[string]Counter `json:"responses"`
+	StreamResponses      map[string]Counter `json:"stream_responses"`
+	WorkerDeaths         Counter            `json:"worker_deaths"`
+	WorkersStarted       Counter            `json:"workers_started"`
+	ClusterIsStable      Counter            `json:"cluster_is_stable"`
+	DbScans              Counter            `json:"db_scans"`
+	Docs                 map[string]Counter `json:"docs"`
+	Jobs                 map[string]Counter `json:"jobs"`
+	Connection           map[string]Counter `json:"connection"`
+}
+
 type StatsResponse struct {
 	Couchdb  CouchdbStats `json:"couchdb"`
 	Up       float64      `json:"-"`
@@ -113,8 +132,9 @@ type StatsResponse struct {
 	HttpdRequestMethods HttpdRequestMethods `json:"httpd_request_methods"`
 	HttpdStatusCodes    HttpdStatusCodes    `json:"httpd_status_codes"`
 	// v2.x api
-	CouchLog LogLevel `json:"couch_log"`
-	Fabric   Fabric   `json:"fabric"`
+	CouchLog        LogLevel        `json:"couch_log"`
+	Fabric          Fabric          `json:"fabric"`
+	CouchReplicator CouchReplicator `json:"couch_replicator"`
 }
 
 type View map[string]interface{}

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -55,6 +55,14 @@ type Exporter struct {
 
 	couchLog *prometheus.GaugeVec
 
+	fabricWorker            *prometheus.GaugeVec
+	fabricOpenShard         *prometheus.GaugeVec
+	fabricReadRepairs       *prometheus.GaugeVec
+	fabricFailure           *prometheus.GaugeVec
+	fabricDocUpdate         *prometheus.GaugeVec
+	fabricMismatchedErrors  *prometheus.GaugeVec
+	fabricWriteQuorumErrors *prometheus.GaugeVec
+
 	nodeMemoryOther         *prometheus.GaugeVec
 	nodeMemoryAtom          *prometheus.GaugeVec
 	nodeMemoryAtomUsed      *prometheus.GaugeVec
@@ -428,5 +436,41 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Help:      "scheduler jobs",
 			},
 			[]string{"node_name", "job_id", "db_name", "doc_id", "source", "target"}),
+
+		fabricWorker: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "fabric",
+				Name:      "worker",
+				Help:      "worker metrics",
+			},
+			[]string{"metric", "node_name"}),
+
+		fabricOpenShard: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "fabric",
+				Name:      "open_shard",
+				Help:      "open_shard metrics",
+			},
+			[]string{"metric", "node_name"}),
+
+		fabricReadRepairs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "fabric",
+				Name:      "read_repairs",
+				Help:      "read repair metrics",
+			},
+			[]string{"metric", "node_name"}),
+
+		fabricDocUpdate: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "fabric",
+				Name:      "doc_update",
+				Help:      "doc update metrics",
+			},
+			[]string{"metric", "node_name"}),
 	}
 }

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -63,6 +63,23 @@ type Exporter struct {
 	fabricMismatchedErrors  *prometheus.GaugeVec
 	fabricWriteQuorumErrors *prometheus.GaugeVec
 
+	couchReplicatorChangesReadFailures  *prometheus.GaugeVec
+	couchReplicatorChangesReaderDeaths  *prometheus.GaugeVec
+	couchReplicatorChangesManagerDeaths *prometheus.GaugeVec
+	couchReplicatorChangesQueueDeaths   *prometheus.GaugeVec
+	couchReplicatorCheckpoints          *prometheus.GaugeVec
+	couchReplicatorFailedStarts         *prometheus.GaugeVec
+	couchReplicatorRequests             *prometheus.GaugeVec
+	couchReplicatorResponses            *prometheus.GaugeVec
+	couchReplicatorStreamResponses      *prometheus.GaugeVec
+	couchReplicatorWorkerDeaths         *prometheus.GaugeVec
+	couchReplicatorWorkersStarted       *prometheus.GaugeVec
+	couchReplicatorClusterIsStable      *prometheus.GaugeVec
+	couchReplicatorDbScans              *prometheus.GaugeVec
+	couchReplicatorDocs                 *prometheus.GaugeVec
+	couchReplicatorJobs                 *prometheus.GaugeVec
+	couchReplicatorConnection           *prometheus.GaugeVec
+
 	nodeMemoryOther         *prometheus.GaugeVec
 	nodeMemoryAtom          *prometheus.GaugeVec
 	nodeMemoryAtomUsed      *prometheus.GaugeVec
@@ -470,6 +487,150 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Subsystem: "fabric",
 				Name:      "doc_update",
 				Help:      "doc update metrics",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorChangesReadFailures: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "changes_read_failures",
+				Help:      "number of failed replicator changes read failures",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorChangesReaderDeaths: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "changes_reader_deaths",
+				Help:      "number of failed replicator changes readers",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorChangesManagerDeaths: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "changes_manager_deaths",
+				Help:      "number of failed replicator changes managers",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorChangesQueueDeaths: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "changes_queue_deaths",
+				Help:      "number of failed replicator changes work queues",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorCheckpoints: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "checkpoints",
+				Help:      "replicator checkpoint counters",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorFailedStarts: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "failed_starts",
+				Help:      "number of replications that have failed to start",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorRequests: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "requests",
+				Help:      "number of HTTP requests made by the replicator",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorResponses: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "responses",
+				Help:      "number of HTTP responses by state",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorStreamResponses: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "stream_responses",
+				Help:      "number of streaming HTTP responses by state",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorWorkerDeaths: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "worker_deaths",
+				Help:      "number of failed replicator workers",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorWorkersStarted: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "workers_started",
+				Help:      "number of replicator workers started",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorClusterIsStable: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "cluster_is_stable",
+				Help:      "1 if cluster is stable, 0 if unstable",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorDbScans: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "db_scans",
+				Help:      "number of times replicator db scans have been started",
+			},
+			[]string{"node_name"}),
+
+		couchReplicatorDocs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "docs",
+				Help:      "replicator metrics shown by type",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorJobs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "jobs",
+				Help:      "replicator jobs shown by type",
+			},
+			[]string{"metric", "node_name"}),
+
+		couchReplicatorConnection: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "replicator",
+				Name:      "connections",
+				Help:      "replicator connection metrics shown by type",
 			},
 			[]string{"metric", "node_name"}),
 	}

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -55,6 +55,15 @@ type Exporter struct {
 
 	couchLog *prometheus.GaugeVec
 
+	nodeMemoryOther         *prometheus.GaugeVec
+	nodeMemoryAtom          *prometheus.GaugeVec
+	nodeMemoryAtomUsed      *prometheus.GaugeVec
+	nodeMemoryProcesses     *prometheus.GaugeVec
+	nodeMemoryProcessesUsed *prometheus.GaugeVec
+	nodeMemoryBinary        *prometheus.GaugeVec
+	nodeMemoryCode          *prometheus.GaugeVec
+	nodeMemoryEts           *prometheus.GaugeVec
+
 	viewStaleness *prometheus.GaugeVec
 
 	schedulerJobs *prometheus.GaugeVec
@@ -329,6 +338,78 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Help:      "number of messages logged by log level",
 			},
 			[]string{"level", "node_name"}),
+
+		nodeMemoryOther: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_other",
+				Help:      "erlang memory counters - other",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryAtom: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_atom",
+				Help:      "erlang memory counters - atom",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryAtomUsed: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_atom_used",
+				Help:      "erlang memory counters - atom_used",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryProcesses: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_processes",
+				Help:      "erlang memory counters - processes",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryProcessesUsed: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_processes_used",
+				Help:      "erlang memory counters - processes_used",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryBinary: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_binary",
+				Help:      "erlang memory counters - binary",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryCode: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_code",
+				Help:      "erlang memory counters - code",
+			},
+			[]string{"node_name"}),
+
+		nodeMemoryEts: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "erlang",
+				Name:      "memory_ets",
+				Help:      "erlang memory counters - ets",
+			},
+			[]string{"node_name"}),
 
 		viewStaleness: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -1,8 +1,9 @@
 package lib
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -51,6 +52,8 @@ type Exporter struct {
 	activeTasksIndexer               *prometheus.GaugeVec
 	activeTasksReplication           *prometheus.GaugeVec
 	activeTasksReplicationLastUpdate *prometheus.GaugeVec
+
+	couchLog *prometheus.GaugeVec
 
 	viewStaleness *prometheus.GaugeVec
 
@@ -317,6 +320,15 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Help:      "active tasks",
 			},
 			[]string{"node_name", "doc_id", "continuous", "source", "target"}),
+
+		couchLog: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "server",
+				Name:      "couch_log",
+				Help:      "number of messages logged by log level",
+			},
+			[]string{"level", "node_name"}),
 
 		viewStaleness: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
Hello,

I needed to add more metrics to use at work. This is the result of the changes I made. I also updated the tests to include the number of new metrics and requests.

Build output:

++ pwd
+ CWD=/Users/kobusc/work/builds/couchdb-prometheus-exporter
+ export SOURCE=/Users/kobusc/clones/couchdb-prometheus-exporter
+ SOURCE=/Users/kobusc/clones/couchdb-prometheus-exporter
+ export GOPATH=/Users/kobusc/work/builds/couchdb-prometheus-exporter/go
+ GOPATH=/Users/kobusc/work/builds/couchdb-prometheus-exporter/go
+ export APPPATH=/Users/kobusc/work/builds/couchdb-prometheus-exporter/go/src/github.com/gesellix/couchdb-prometheus-exporter
+ APPPATH=/Users/kobusc/work/builds/couchdb-prometheus-exporter/go/src/github.com/gesellix/couchdb-prometheus-exporter
+ mkdir -p /Users/kobusc/work/builds/couchdb-prometheus-exporter/go/src/github.com/gesellix/couchdb-prometheus-exporter
+ cp -r /Users/kobusc/clones/couchdb-prometheus-exporter/CODE_OF_CONDUCT.md /Users/kobusc/clones/couchdb-prometheus-exporter/Dockerfile /Users/kobusc/clones/couchdb-prometheus-exporter/Gopkg.lock /Users/kobusc/clones/couchdb-prometheus-exporter/Gopkg.toml /Users/kobusc/clones/couchdb-prometheus-exporter/LICENSE /Users/kobusc/clones/couchdb-prometheus-exporter/README.md /Users/kobusc/clones/couchdb-prometheus-exporter/cli /Users/kobusc/clones/couchdb-prometheus-exporter/couchdb-exporter.go /Users/kobusc/clones/couchdb-prometheus-exporter/couchdb-exporter_test.go /Users/kobusc/clones/couchdb-prometheus-exporter/examples /Users/kobusc/clones/couchdb-prometheus-exporter/glogadapt /Users/kobusc/clones/couchdb-prometheus-exporter/integrationtest-setup.sh /Users/kobusc/clones/couchdb-prometheus-exporter/integrationtest-teardown.sh /Users/kobusc/clones/couchdb-prometheus-exporter/lib /Users/kobusc/clones/couchdb-prometheus-exporter/munin /Users/kobusc/clones/couchdb-prometheus-exporter/testdata /Users/kobusc/clones/couchdb-prometheus-exporter/testutil /Users/kobusc/clones/couchdb-prometheus-exporter/vendor /Users/kobusc/work/builds/couchdb-prometheus-exporter/go/src/github.com/gesellix/couchdb-prometheus-exporter/.
+ cd /Users/kobusc/work/builds/couchdb-prometheus-exporter/go/src/github.com/gesellix/couchdb-prometheus-exporter
+ go get -d
+ go get -u github.com/golang/dep/cmd/dep
+ /Users/kobusc/work/builds/couchdb-prometheus-exporter/go/bin/dep ensure
+ go test -short
PASS
ok  	github.com/gesellix/couchdb-prometheus-exporter	0.048s
+ go build -a -ldflags '-s -w -extldflags "-static"' -o ./bin/couchdb-prometheus-exporter