### PR TITLE
Add '-concurrency' flag and logic to limit concurrent scrape

### DIFF
--- a/couchdb-exporter.go
+++ b/couchdb-exporter.go
@@ -127,7 +127,7 @@ func init() {
 		}),
 		altsrc.NewUintFlag(cli.UintFlag{
 			Name:        "database.concurrent.requests",
-			Usage:       "maximum concurrent calls to couchDB, or 0 for unlimited",
+			Usage:       "maximum concurrent calls to CouchDB, or 0 for unlimited",
 			Value:       0,
 			Hidden:      false,
 			Destination: &exporterConfig.databaseConcurrentRequests,

--- a/couchdb-exporter.go
+++ b/couchdb-exporter.go
@@ -27,6 +27,7 @@ type exporterConfigType struct {
 	couchdbInsecure bool
 	databases       string
 	databaseViews   bool
+	concurrency     uint
 	schedulerJobs   bool
 }
 
@@ -124,6 +125,13 @@ func init() {
 			Hidden:      false,
 			Destination: &exporterConfig.databaseViews,
 		}),
+		altsrc.NewUintFlag(cli.UintFlag{
+			Name:        "concurrency",
+			Usage:       "maximum concurrent calls to couchDB, or 0 for unlimited",
+			Value:       0,
+			Hidden:      false,
+			Destination: &exporterConfig.concurrency,
+		}),
 		// TODO doesn't print the default when showing the command help
 		altsrc.NewBoolFlag(cli.BoolFlag{
 			Name:        "scheduler.jobs",
@@ -185,6 +193,7 @@ func main() {
 				Databases:            databases,
 				CollectViews:         *&exporterConfig.databaseViews,
 				CollectSchedulerJobs: *&exporterConfig.schedulerJobs,
+				Concurrency:          *&exporterConfig.concurrency,
 			},
 			*&exporterConfig.couchdbInsecure)
 		prometheus.MustRegister(exporter)

--- a/couchdb-exporter.go
+++ b/couchdb-exporter.go
@@ -19,16 +19,16 @@ import (
 )
 
 type exporterConfigType struct {
-	listenAddress   string
-	metricsEndpoint string
-	couchdbURI      string
-	couchdbUsername string
-	couchdbPassword string
-	couchdbInsecure bool
-	databases       string
-	databaseViews   bool
-	concurrency     uint
-	schedulerJobs   bool
+	listenAddress              string
+	metricsEndpoint            string
+	couchdbURI                 string
+	couchdbUsername            string
+	couchdbPassword            string
+	couchdbInsecure            bool
+	databases                  string
+	databaseViews              bool
+	databaseConcurrentRequests uint
+	schedulerJobs              bool
 }
 
 type loggingConfigType struct {
@@ -126,11 +126,11 @@ func init() {
 			Destination: &exporterConfig.databaseViews,
 		}),
 		altsrc.NewUintFlag(cli.UintFlag{
-			Name:        "concurrency",
+			Name:        "database.concurrent.requests",
 			Usage:       "maximum concurrent calls to couchDB, or 0 for unlimited",
 			Value:       0,
 			Hidden:      false,
-			Destination: &exporterConfig.concurrency,
+			Destination: &exporterConfig.databaseConcurrentRequests,
 		}),
 		// TODO doesn't print the default when showing the command help
 		altsrc.NewBoolFlag(cli.BoolFlag{
@@ -193,7 +193,7 @@ func main() {
 				Databases:            databases,
 				CollectViews:         *&exporterConfig.databaseViews,
 				CollectSchedulerJobs: *&exporterConfig.schedulerJobs,
-				Concurrency:          *&exporterConfig.concurrency,
+				ConcurrentRequests:   *&exporterConfig.databaseConcurrentRequests,
 			},
 			*&exporterConfig.couchdbInsecure)
 		prometheus.MustRegister(exporter)

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -75,6 +75,7 @@ type CollectorConfig struct {
 	ObservedDatabases    []string
 	CollectViews         bool
 	CollectSchedulerJobs bool
+	Concurrency          uint
 }
 
 type ActiveTaskTypes struct {

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -75,7 +75,7 @@ type CollectorConfig struct {
 	ObservedDatabases    []string
 	CollectViews         bool
 	CollectSchedulerJobs bool
-	Concurrency          uint
+	ConcurrentRequests   uint
 }
 
 type ActiveTaskTypes struct {

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -351,7 +351,9 @@ func (c *CouchdbClient) enhanceWithViewUpdateSeq(dbStatsByDbName map[string]Data
 			for _, row := range designDocs.Rows {
 				row := row
 				go func() {
-					defer func() { done <- struct{}{} }()
+					defer func() {
+						done <- struct{}{}
+					}()
 					updateSeqByView := make(ViewStats)
 					type viewresult struct {
 						viewName  string
@@ -366,7 +368,7 @@ func (c *CouchdbClient) enhanceWithViewUpdateSeq(dbStatsByDbName map[string]Data
 							err := semaphore.Acquire()
 							if err != nil {
 								// send something to parent coroutine so it doesn't block forever on receive
-								v <- viewresult{err: fmt.Errorf("Aborted view stats for /%s/%s/_view/%s", dbName, row.Doc.Id, viewName)}
+								v <- viewresult{err: fmt.Errorf("aborted view stats for /%s/%s/_view/%s", dbName, row.Doc.Id, viewName)}
 								return
 							}
 							query := strings.Join([]string{
@@ -579,7 +581,7 @@ func NewSemaphore(concurrency uint) Semaphore {
 func (s Semaphore) Acquire() error {
 	select {
 	case <-s.abort:
-		return fmt.Errorf("Could not acquire semaphore")
+		return fmt.Errorf("could not acquire semaphore")
 	case <-s.sem:
 		return nil
 	}
@@ -594,7 +596,7 @@ func (s Semaphore) Release() {
 	}
 }
 
-// Signal abort for anyone waiting on the Semaphor
+// Signal abort for anyone waiting on the Semaphore
 func (s Semaphore) Abort() {
 	select {
 	case <-s.abort:

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -183,12 +183,12 @@ func (c *CouchdbClient) getStats(config CollectorConfig) (Stats, error) {
 		if err != nil {
 			return Stats{}, err
 		}
-		databaseStats, err := c.getDatabasesStatsByDbName(config.ObservedDatabases, config.Concurrency)
+		databaseStats, err := c.getDatabasesStatsByDbName(config.ObservedDatabases, config.ConcurrentRequests)
 		if err != nil {
 			return Stats{}, err
 		}
 		if config.CollectViews {
-			err := c.enhanceWithViewUpdateSeq(databaseStats, config.Concurrency)
+			err := c.enhanceWithViewUpdateSeq(databaseStats, config.ConcurrentRequests)
 			if err != nil {
 				return Stats{}, err
 			}
@@ -226,12 +226,12 @@ func (c *CouchdbClient) getStats(config CollectorConfig) (Stats, error) {
 		if err != nil {
 			return Stats{}, err
 		}
-		databaseStats, err := c.getDatabasesStatsByDbName(config.ObservedDatabases, config.Concurrency)
+		databaseStats, err := c.getDatabasesStatsByDbName(config.ObservedDatabases, config.ConcurrentRequests)
 		if err != nil {
 			return Stats{}, err
 		}
 		if config.CollectViews {
-			err := c.enhanceWithViewUpdateSeq(databaseStats, config.Concurrency)
+			err := c.enhanceWithViewUpdateSeq(databaseStats, config.ConcurrentRequests)
 			if err != nil {
 				return Stats{}, err
 			}

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -384,6 +384,8 @@ func (c *CouchdbClient) enhanceWithViewUpdateSeq(dbStatsByDbName map[string]Data
 						//klog.Infof("/%s/%s/_view/%s\n", dbName, row.Doc.Id, viewName)
 						select {
 						case <-abort:
+							// send something to parent coroutine so it doesn't block forever on receive
+							v <- viewresult{err: fmt.Errorf("Aborted view stats for /%s/%s/_view/%s", dbName, row.Doc.Id, viewName)}
 							return
 						case <-semaphore:
 						}

--- a/lib/couchdb-client_test.go
+++ b/lib/couchdb-client_test.go
@@ -55,7 +55,7 @@ func TestSerialSemaphore(t *testing.T) {
 	}
 	sem.Release()
 	time.Sleep(20 * time.Millisecond)
-	if len(results) > 20 { // should never complete this many in the alotted time
+	if len(results) > 20 { // should never complete this many in the allotted time
 		t.Error("Workers completed job too fast", len(results))
 	}
 }

--- a/lib/couchdb-client_test.go
+++ b/lib/couchdb-client_test.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"testing"
+	"time"
+)
+
+// worker goroutine; should take no less than 1ms to complete.
+func worker(sem Semaphore, results chan struct{}) {
+	err := sem.Acquire()
+	if err != nil {
+		return
+	}
+	time.Sleep(1 * time.Millisecond)
+	results <- struct{}{}
+	sem.Release()
+}
+
+func TestSemaphore(t *testing.T) {
+	// Test1: test concurrent workers, limited to 10 at a time.
+	sem := NewSemaphore(10)
+	// channel buffered to receive all results
+	results := make(chan struct{}, 100)
+
+	for i := 0; i < 100; i++ {
+		go worker(sem, results)
+	}
+	time.Sleep(20 * time.Millisecond) // plenty of time
+	if len(results) != 100 {
+		t.Error("Workers did not complete in time")
+	}
+}
+
+func TestUnlimitedSemaphore(t *testing.T) {
+	// Test2: test unlimited concurrent workers
+	sem := NewSemaphore(0)
+	results := make(chan struct{}, 100)
+
+	for i := 0; i < 100; i++ {
+		go worker(sem, results)
+	}
+	time.Sleep(20 * time.Millisecond) // plenty of time
+	if len(results) != 100 {
+		t.Error("Workers did not complete in time")
+	}
+}
+
+func TestSerialSemaphore(t *testing.T) {
+	// Test3: test serialised workers, ie. 1 at a time;
+	sem := NewSemaphore(1)
+	results := make(chan struct{}, 100)
+	sem.Acquire()
+	for i := 0; i < 100; i++ {
+		go worker(sem, results)
+	}
+	sem.Release()
+	time.Sleep(20 * time.Millisecond)
+	if len(results) > 20 { // should never complete this many in the alotted time
+		t.Error("Workers completed job too fast", len(results))
+	}
+}
+
+func TestAbort(t *testing.T) {
+	// Test abort functionality
+	sem := NewSemaphore(1)
+	results := make(chan struct{}, 100)
+	for i := 0; i < 100; i++ {
+		go worker(sem, results)
+	}
+	// let workers make some progress
+	time.Sleep(10 * time.Millisecond)
+	sem.Abort()
+	time.Sleep(200 * time.Millisecond)
+	// there should never be 100 results
+	if len(results) == 100 {
+		t.Error("Somehow all workers completed their jobs despite an abort")
+	}
+}


### PR DESCRIPTION
This change adds a flag to limit the concurrent HTTP requests the exporter makes when scraping per-database and per-view stats.  This might be useful for people with thousand of DBs or views.

I've tested quite extensively on my setup, `-concurrency=1` takes me 17s to scrape; whereas 5 takes me 7s, etc. up to 3.5s with 0 (unlimited)