### PR TITLE
:bug: Fix url escaping database name

### DIFF
--- a/couchdb-exporter_test.go
+++ b/couchdb-exporter_test.go
@@ -200,7 +200,7 @@ func TestCouchdbStatsV1Integration(t *testing.T) {
 	client := lib.NewCouchdbClient(dbUrl, basicAuth, true)
 	databases := []string{"v1_testdb1", "v1_test/db2"}
 	for _, db := range databases {
-		_, err = client.Request("PUT", fmt.Sprintf("%s/%s", client.BaseUri, url.PathEscape(db)), nil)
+		_, err = client.Request("PUT", fmt.Sprintf("%s/%s", client.BaseUri, url.QueryEscape(db)), nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -257,7 +257,7 @@ func TestCouchdbStatsV1Integration(t *testing.T) {
 	})
 
 	for _, db := range databases {
-		_, err = client.Request("DELETE", fmt.Sprintf("%s/%s", client.BaseUri, url.PathEscape(db)), nil)
+		_, err = client.Request("DELETE", fmt.Sprintf("%s/%s", client.BaseUri, url.QueryEscape(db)), nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -310,7 +310,7 @@ func TestCouchdbStatsV2Integration(t *testing.T) {
 	client := lib.NewCouchdbClient(dbUrl, basicAuth, true)
 	databases := []string{"v2_testdb1", "v2_test/db2"}
 	for _, db := range databases {
-		_, err = client.Request("PUT", fmt.Sprintf("%s/%s", client.BaseUri, url.PathEscape(db)), nil)
+		_, err = client.Request("PUT", fmt.Sprintf("%s/%s", client.BaseUri, url.QueryEscape(db)), nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -367,7 +367,7 @@ func TestCouchdbStatsV2Integration(t *testing.T) {
 	})
 
 	for _, db := range databases {
-		_, err = client.Request("DELETE", fmt.Sprintf("%s/%s", client.BaseUri, url.PathEscape(db)), nil)
+		_, err = client.Request("DELETE", fmt.Sprintf("%s/%s", client.BaseUri, url.QueryEscape(db)), nil)
 		if err != nil {
 			t.Error(err)
 		}

--- a/lib/couchdb-client.go
+++ b/lib/couchdb-client.go
@@ -277,7 +277,7 @@ func (c *CouchdbClient) getDatabasesStatsByDbName(databases []string, concurrenc
 	// scatter
 	for _, dbName := range databases {
 		dbName := dbName // rebind for closure to capture the value
-		escapedDbName := url.PathEscape(dbName)
+		escapedDbName := url.QueryEscape(dbName)
 		go func() {
 			err := semaphore.Acquire()
 			if err != nil {
@@ -329,7 +329,7 @@ type viewStats struct {
 }
 
 func (c *CouchdbClient) viewStats(isCouchdbV1 bool, dbName string, designDocId string, viewName string) viewStats {
-	escapedDbName := url.PathEscape(dbName)
+	escapedDbName := url.QueryEscape(dbName)
 
 	query := strings.Join([]string{
 		"stale=ok",
@@ -397,7 +397,7 @@ func (c *CouchdbClient) enhanceWithViewUpdateSeq(isCouchdbV1 bool, dbStatsByDbNa
 	for dbName, dbStats := range dbStatsByDbName {
 		dbName := dbName   // rebind for closure to capture the value
 		dbStats := dbStats // rebind for closure to capture the value
-		escapedDbName := url.PathEscape(dbName)
+		escapedDbName := url.QueryEscape(dbName)
 		go func() {
 			err := semaphore.Acquire()
 			if err != nil {


### PR DESCRIPTION
Using `QueryEscape` instead of `PathEscape` prevent the bug described [here](https://github.com/gesellix/couchdb-prometheus-exporter/issues/84) 