### PR TITLE
Add new metric for "changes_pending" from /_active_tasks

### DIFF
--- a/couchdb-exporter_test.go
+++ b/couchdb-exporter_test.go
@@ -173,15 +173,15 @@ func performCouchdbStatsTest(t *testing.T, couchdbVersion string, expectedMetric
 }
 
 func TestCouchdbStatsV1(t *testing.T) {
-	performCouchdbStatsTest(t, "v1", 58, 4711, 12396, 11)
+	performCouchdbStatsTest(t, "v1", 59, 4711, 12396, 11)
 }
 
 func TestCouchdbStatsV2(t *testing.T) {
-	performCouchdbStatsTest(t, "v2", 306, 4712, 58570, 17)
+	performCouchdbStatsTest(t, "v2", 307, 4712, 58570, 17)
 }
 
 func TestCouchdbStatsV2Prerelease(t *testing.T) {
-	performCouchdbStatsTest(t, "v2-pre", 294, 4712, 58570, 17)
+	performCouchdbStatsTest(t, "v2-pre", 295, 4712, 58570, 17)
 }
 
 func TestCouchdbStatsV1Integration(t *testing.T) {

--- a/lib/collector-v1.go
+++ b/lib/collector-v1.go
@@ -83,6 +83,12 @@ func (e *Exporter) collectV1(stats Stats, exposedHttpStatusCodes []string, colle
 				strconv.FormatBool(task.Continuous),
 				task.Source,
 				task.Target).Set(task.UpdatedOn)
+			e.activeTasksReplicationChangesPending.WithLabelValues(
+				task.Node,
+				task.DocId,
+				strconv.FormatBool(task.Continuous),
+				task.Source,
+				task.Target).Set(float64(task.ChangesPending))
 		}
 
 		if _, ok := activeTasksByNode[task.Node]; !ok {

--- a/lib/collector-v2.go
+++ b/lib/collector-v2.go
@@ -211,6 +211,12 @@ func (e *Exporter) collectV2(stats Stats, exposedHttpStatusCodes []string, colle
 				strconv.FormatBool(task.Continuous),
 				task.Source,
 				task.Target).Set(task.UpdatedOn)
+			e.activeTasksReplicationChangesPending.WithLabelValues(
+				task.Node,
+				task.DocId,
+				strconv.FormatBool(task.Continuous),
+				task.Source,
+				task.Target).Set(float64(task.ChangesPending))
 		}
 
 		if _, ok := activeTasksByNode[task.Node]; !ok {

--- a/lib/collector.go
+++ b/lib/collector.go
@@ -140,6 +140,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.activeTasksIndexer.Describe(ch)
 	e.activeTasksReplication.Describe(ch)
 	e.activeTasksReplicationLastUpdate.Describe(ch)
+	e.activeTasksReplicationChangesPending.Describe(ch)
 
 	e.couchLog.Describe(ch)
 
@@ -226,6 +227,7 @@ func (e *Exporter) resetAllMetrics() {
 		e.activeTasksIndexer,
 		e.activeTasksReplication,
 		e.activeTasksReplicationLastUpdate,
+		e.activeTasksReplicationChangesPending,
 
 		e.couchLog,
 
@@ -361,6 +363,7 @@ func (e *Exporter) collect(ch chan<- prometheus.Metric) error {
 	e.activeTasksIndexer.Collect(ch)
 	e.activeTasksReplication.Collect(ch)
 	e.activeTasksReplicationLastUpdate.Collect(ch)
+	e.activeTasksReplicationChangesPending.Collect(ch)
 
 	e.couchLog.Collect(ch)
 

--- a/lib/couchdb-stats.go
+++ b/lib/couchdb-stats.go
@@ -210,13 +210,14 @@ type DatabaseStats struct {
 type DatabaseStatsByDbName map[string]DatabaseStats
 
 type ActiveTask struct {
-	Type       string  `json:"type"`
-	Node       string  `json:"node,omitempty"`
-	Continuous bool    `json:"continuous,omitempty"`
-	UpdatedOn  float64 `json:"updated_on,omitempty"`
-	Source     string  `json:"source,omitempty"`
-	Target     string  `json:"target,omitempty"`
-	DocId      string  `json:"doc_id,omitempty"`
+	Type           string  `json:"type"`
+	Node           string  `json:"node,omitempty"`
+	ChangesPending int     `json:"changes_pending,omitempty"`
+	Continuous     bool    `json:"continuous,omitempty"`
+	UpdatedOn      float64 `json:"updated_on,omitempty"`
+	Source         string  `json:"source,omitempty"`
+	Target         string  `json:"target,omitempty"`
+	DocId          string  `json:"doc_id,omitempty"`
 }
 
 type ActiveTasksResponse []ActiveTask

--- a/lib/exporter.go
+++ b/lib/exporter.go
@@ -47,12 +47,13 @@ type Exporter struct {
 	compactRunning   *prometheus.GaugeVec
 	diskSizeOverhead *prometheus.GaugeVec
 
-	activeTasks                      *prometheus.GaugeVec
-	activeTasksDatabaseCompaction    *prometheus.GaugeVec
-	activeTasksViewCompaction        *prometheus.GaugeVec
-	activeTasksIndexer               *prometheus.GaugeVec
-	activeTasksReplication           *prometheus.GaugeVec
-	activeTasksReplicationLastUpdate *prometheus.GaugeVec
+	activeTasks                          *prometheus.GaugeVec
+	activeTasksDatabaseCompaction        *prometheus.GaugeVec
+	activeTasksViewCompaction            *prometheus.GaugeVec
+	activeTasksIndexer                   *prometheus.GaugeVec
+	activeTasksReplication               *prometheus.GaugeVec
+	activeTasksReplicationLastUpdate     *prometheus.GaugeVec
+	activeTasksReplicationChangesPending *prometheus.GaugeVec
 
 	couchLog *prometheus.GaugeVec
 
@@ -333,7 +334,7 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Namespace: namespace,
 				Subsystem: "server",
 				Name:      "active_tasks_database_compaction",
-				Help:      "active tasks",
+				Help:      "active tasks database compaction",
 			},
 			[]string{"node_name"}),
 		activeTasksViewCompaction: prometheus.NewGaugeVec(
@@ -341,7 +342,7 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Namespace: namespace,
 				Subsystem: "server",
 				Name:      "active_tasks_view_compaction",
-				Help:      "active tasks",
+				Help:      "active tasks view compaction",
 			},
 			[]string{"node_name"}),
 		activeTasksIndexer: prometheus.NewGaugeVec(
@@ -349,7 +350,7 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Namespace: namespace,
 				Subsystem: "server",
 				Name:      "active_tasks_indexer",
-				Help:      "active tasks",
+				Help:      "active tasks indexer",
 			},
 			[]string{"node_name"}),
 		activeTasksReplication: prometheus.NewGaugeVec(
@@ -357,7 +358,7 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Namespace: namespace,
 				Subsystem: "server",
 				Name:      "active_tasks_replication",
-				Help:      "active tasks",
+				Help:      "active tasks replication",
 			},
 			[]string{"node_name"}),
 
@@ -366,7 +367,16 @@ func NewExporter(uri string, basicAuth BasicAuth, collectorConfig CollectorConfi
 				Namespace: namespace,
 				Subsystem: "server",
 				Name:      "active_tasks_replication_updated_on",
-				Help:      "active tasks",
+				Help:      "active tasks replication updated on",
+			},
+			[]string{"node_name", "doc_id", "continuous", "source", "target"}),
+
+		activeTasksReplicationChangesPending: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: "server",
+				Name:      "active_tasks_replication_changes_pending",
+				Help:      "active tasks replication changes pending ",
 			},
 			[]string{"node_name", "doc_id", "continuous", "source", "target"}),
 


### PR DESCRIPTION
Querying `/_active_tasks` works for CouchDB 1.x and above. Yet, CouchDB 2.x provides a dedicated endpoint `/_scheduler/jobs` and yet another one since CouchDB 2.1.0 at `/_scheduler/docs`, with overlapping semantics. We should aim at providing the `/_scheduler/*` metrics as well, when observing a modern CouchDB setup. We should also keep in mind that CouchDB 3.2 introduced a native `/_node/.../_prometheus` endpoint, which _currently_ doesn't provide replication stats.

Relates to #110

Related docs:
- [Active tasks endpoint](https://docs.couchdb.org/en/stable/api/server/common.html#active-tasks)
- [Scheduler jobs endpoint](https://docs.couchdb.org/en/stable/api/server/common.html#scheduler-jobs)
- [Scheduler docs endpoint](https://docs.couchdb.org/en/stable/api/server/common.html#scheduler-docs)
- [CouchDB 2.1.0 release notes](https://docs.couchdb.org/en/stable/whatsnew/2.1.html#version-2-1-0)
- [Prometheus endpoint](https://docs.couchdb.org/en/stable/api/server/common.html#node-node-name-prometheus)
- [CouchDB 3.2.0 release notes](https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-0)
