### PR TITLE
Upgrade integration tests to CouchDB 3.3.0

### DIFF
--- a/examples/compose/docker-compose-integrationtest.yml
+++ b/examples/compose/docker-compose-integrationtest.yml
@@ -11,7 +11,7 @@ services:
       - "4895:5984"
 
   couchdb_node_1:
-    image: couchdb:3.2.2
+    image: couchdb:3.3.0
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -26,7 +26,7 @@ services:
       - "15984:5984"
 
   couchdb_node_2:
-    image: couchdb:3.2.2
+    image: couchdb:3.3.0
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -41,7 +41,7 @@ services:
       - "25984:5984"
 
   couchdb_node_3:
-    image: couchdb:3.2.2
+    image: couchdb:3.3.0
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -80,7 +80,7 @@ services:
       - "9985:9984"
 
   cluster-setup:
-    image: gesellix/couchdb-cluster-config:v17.0.0
+    image: gesellix/couchdb-cluster-config:v17.2.8
     command: setup --delay 10s --timeout 30s --username ${COUCHDB_USER:-root} --password ${COUCHDB_PASSWORD:-a-secret} -nodes 172.16.238.11 -nodes 172.16.238.12 -nodes 172.16.238.13
     networks:
       couchdb-cluster:


### PR DESCRIPTION
See https://blog.couchdb.org/2023/01/03/3-3-0/ and https://docs.couchdb.org/en/stable/whatsnew/3.3.html