### PR TITLE
Upgrade integration tests to CouchDB 3.3.1

### DIFF
--- a/examples/compose/docker-compose-integrationtest.yml
+++ b/examples/compose/docker-compose-integrationtest.yml
@@ -11,7 +11,7 @@ services:
       - "4895:5984"
 
   couchdb_node_1:
-    image: couchdb:3.3.0
+    image: couchdb:3.3.1
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -26,7 +26,7 @@ services:
       - "15984:5984"
 
   couchdb_node_2:
-    image: couchdb:3.3.0
+    image: couchdb:3.3.1
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -41,7 +41,7 @@ services:
       - "25984:5984"
 
   couchdb_node_3:
-    image: couchdb:3.3.0
+    image: couchdb:3.3.1
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"


### PR DESCRIPTION
See https://blog.couchdb.org/2023/01/11/3-3-1/ and https://docs.couchdb.org/en/stable/whatsnew/3.3.html