### PR TITLE
Bump couchdb in examples and tests to 3.3.3

### DIFF
--- a/examples/compose/docker-compose-cluster.yml
+++ b/examples/compose/docker-compose-cluster.yml
@@ -2,7 +2,7 @@ version: "2.3"
 
 services:
   couchdb1:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -name couchdb@172.16.238.11 -setcookie thecookie
     env_file: .couchdb-env
     restart: always
@@ -13,7 +13,7 @@ services:
       - "15984:5984"
 
   couchdb2:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -name couchdb@172.16.238.12 -setcookie thecookie
     env_file: .couchdb-env
     restart: always
@@ -24,7 +24,7 @@ services:
       - "25984:5984"
 
   couchdb3:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -name couchdb@172.16.238.13 -setcookie thecookie
     env_file: .couchdb-env
     restart: always

--- a/examples/compose/docker-compose-integrationtest.yml
+++ b/examples/compose/docker-compose-integrationtest.yml
@@ -11,7 +11,7 @@ services:
       - "4895:5984"
 
   couchdb_node_1:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -26,7 +26,7 @@ services:
       - "15984:5984"
 
   couchdb_node_2:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"
@@ -41,7 +41,7 @@ services:
       - "25984:5984"
 
   couchdb_node_3:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     command: -setcookie thecookie
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-root}"

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   couchdb:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     env_file: .couchdb-env
     restart: always
     volumes:

--- a/examples/grafana/docker-traefik-stack.yml
+++ b/examples/grafana/docker-traefik-stack.yml
@@ -73,7 +73,7 @@ services:
         condition: on-failure
 
   couchdb1:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     hostname: couchdb1.local
     command: -name couchdb@couchdb1.local -setcookie thecookie
     environment:
@@ -94,7 +94,7 @@ services:
         condition: on-failure
 
   couchdb2:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     hostname: couchdb2.local
     command: -name couchdb@couchdb2.local -setcookie thecookie
     environment:
@@ -115,7 +115,7 @@ services:
         condition: on-failure
 
   couchdb3:
-    image: couchdb:3.3.2
+    image: couchdb:3.3.3
     hostname: couchdb3.local
     command: -name couchdb@couchdb3.local -setcookie thecookie
     environment:

--- a/partitioned/run.sh
+++ b/partitioned/run.sh
@@ -18,7 +18,7 @@ docker run --rm -d \
   -v "$(pwd)"/data:/opt/couchdb/data \
   -e COUCHDB_USER=$COUCHDB_USER \
   -e COUCHDB_PASSWORD=$COUCHDB_PASSWORD \
-  couchdb:3.1.0
+  couchdb:3.3.3
 
 sleep 5
 


### PR DESCRIPTION
Release notes: https://docs.couchdb.org/en/stable/whatsnew/3.3.html#version-3-3-3
Announcement: https://blog.couchdb.org/2023/12/05/3-3-3/
